### PR TITLE
Updated influxdb container version to 0.8.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 influxsrv:
-  image: tutum/influxdb
+  image: tutum/influxdb:0.8.8
   name: influxsrv
   ports:
     - "8083:8083"


### PR DESCRIPTION
cAdvisor doesn't yet support InfluxDB 0.9, which is what you get when you pull the latest Docker image for tutum/influxdb.

This shows cAdvisor is using the 0.8.8 InfluxDB client:
https://github.com/google/cadvisor/blob/master/Godeps/Godeps.json#L130-L132

And this shows that the :latest Docker tag points to 0.9:
https://registry.hub.docker.com/u/tutum/influxdb/builds_history/19470/
