### PR TITLE
change to influxdb 0.10, due to upstream registry-1.docker.io unavailable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 influxsrv:
-  image: tutum/influxdb:0.8.8
+  image: tutum/influxdb:0.10
   name: influxsrv
   ports:
     - "8083:8083"


### PR DESCRIPTION
TLS connections timing out - docker registry v1 deprecated.
